### PR TITLE
THREESCALE-10646 - Product Mapping Rules reconciliation - Fix metricMethod issue

### DIFF
--- a/controllers/capabilities/openapi_controller.go
+++ b/controllers/capabilities/openapi_controller.go
@@ -400,6 +400,16 @@ func (r *OpenAPIReconciler) validateOIDCSettingsInCR(openapiCR *capabilitiesv1be
 	specFldPath := field.NewPath("spec")
 	openapiRefFldPath := specFldPath.Child("openapiRef")
 
+	if openapiCR.Spec.OIDC != nil &&
+		(openapiCR.Spec.OIDC.IssuerEndpoint == "" && openapiCR.Spec.OIDC.IssuerEndpointRef == nil) {
+		fieldErrors = append(fieldErrors, field.Invalid(openapiRefFldPath, openapiCR.Spec.OpenAPIRef, "OIDC issuer endpoint definition is missing in CR - "+
+			"No IssuerEndpoint nor IssuerEndpointRef found in OIDC spec in CR, one of them must be set."))
+		return &helper.SpecFieldError{
+			ErrorType:      helper.InvalidError,
+			FieldErrorList: fieldErrors,
+		}
+	}
+
 	globalSecRequirements := helper.OpenAPIGlobalSecurityRequirements(openapiObj)
 	if len(globalSecRequirements) == 0 && openapiCR.Spec.OIDC != nil {
 		logger.Info("OIDC definitions in CR will be ignored, as no security requirements are found. Default to UserKey authentication")

--- a/controllers/capabilities/proxy.go
+++ b/controllers/capabilities/proxy.go
@@ -200,6 +200,10 @@ func (t *ProductThreescaleReconciler) syncProxyOIDC(params threescaleapi.Params,
 	// If plain value is not nil - use plain value as precedence over secret
 	issuerEndpoint := oidcSpec.IssuerEndpoint
 	if issuerEndpoint == "" {
+		if oidcSpec.IssuerEndpointRef == nil {
+			// If missing both IssuerEndpoint and  IssuerEndpointRef in OpenApi CR - Product will fail SyncProxy
+			return fmt.Errorf("missing IssuerEndpoint definition in OIDC spec in openapi CR. Product OpenID Connect Issuer will not be set.")
+		}
 		secretSource := helper.NewSecretSource(t.Client(), t.resource.Namespace)
 		val, err := secretSource.RequiredFieldValueFromRequiredSecret(oidcSpec.IssuerEndpointRef.Name, "issuerEndpoint")
 		if err != nil {

--- a/doc/openapi-user-guide.md
+++ b/doc/openapi-user-guide.md
@@ -147,23 +147,25 @@ spec:
       serviceAccountsEnabled: true
       directAccessGrantsEnabled: true
 ```
-- **oidc** is optional field in OpenAPI CR, Only for OIDC.  
-- **issuerEndpointRef** - Secret, that contains **issuerEndpoint**
-
+- **oidc** is optional field in OpenAPI CR
+- Only for OIDC: 
 
 | **Field**                | **Required** | **Description**                                                                                                                                                                                                                                                                                                                                                                                                                                       |
 | --- | --- | --- |
 | issuerType               | no           | Valid values: [keycloak, rest]. Defaults to `rest`                                                                                                                                                                                                                                                                                                                                                                                                    |
-| issuerEndpoint           | no           | issuerEndpoint can be defined in `issuerEndpointRef` or as plain value (please see CR example and notes below). The format of this endpoint is determined on your OpenID Provider setup. For RHSSO:  https://<client_id>:<client_secret>@<host>:<port>/auth/realms/<realm_name>                                                                                                                                                                       |
+| issuerEndpoint           | no           | Issuer endpoint. It can be defined in `issuerEndpointRef` or as plain value (please see CR example and notes below). The format of this endpoint is determined on your OpenID Provider setup. For RHSSO:  https://<client_id>:<client_secret>@<host>:<port>/auth/realms/<realm_name>                                                                                                                                                                  |
 | issuerEndpointRef        | no           | The secret that contains  `issuerEndpoint`                                                                                                                                                                                                                                                                                                                                                                                                            |
 | jwtClaimWithClientID     | no           | JSON Web Token (JWT) Claim with ClientID that contains the clientID. Defaults to 'azp'.                                                                                                                                                                                                                                                                                                                                                               |
 | jwtClaimWithClientIDType | no           | JwtClaimWithClientIDType sets to process the ClientID Token Claim value as a string or as a liquid template. Valid values: plain, liquid. Defaults to 'plain'                                                                                                                                                                                                                                                                                         |
 | authenticationFlow       | no           | flows object. When the sec scheme is oauth2, the flows are provided by the OpenAPI doc. However, for openIdConnect security scheme, the OpenAPI doc does not provide the flows. In that case, the OpenAPI CR can provide those. There are 4 flows parameters (for OIDC only): `standardFlowEnabled`, `implicitFlowEnabled`, `serviceAccountsEnabled`, `directAccessGrantsEnabled`. See [3scale product reference](product-reference.md) for more info |
 
-
-- **issuerEndpoint** - The format of this endpoint is determined on your OpenID Provider setup.
+- **One of IssuerEndpointRef or IssuerEndpoint must be defined in OIDC Spec** (both fields can be defined, see next note).
+- **If issuerEndpoint plain value is defined in CR - it will be used as precedence over issuerEndpointRef secret**.
+- The format of issuerEndpoint is determined on your OpenID Provider setup;
   see in 3scale portal - `Product/Integration/Settings/AUTHENTICATION SETTINGS/OpenID Connect Issuer`.  
-- **If issuerEndpoint plain value is defined in CR - it will be used as precedence over secret**.   
+
+
+
 OpenAPI CR example where issuerEndpoint defined both as plain value and in secret (plain value will be used):
 ```yaml
 apiVersion: capabilities.3scale.net/v1beta1

--- a/doc/product-reference.md
+++ b/doc/product-reference.md
@@ -125,6 +125,9 @@ Specifies product OIDC authentication mode
 | Security | `security`                 | object | See [SecuritySpec](#SecuritySpec)                                                                                                                                                                             | No           |
 | GatewayResponse | `gatewayResponse`          | object | See [GatewayResponseSpec](#GatewayResponseSpec)                                                                                                                                                               | No           |
 
+- **One of IssuerEndpointRef or IssuerEndpoint must be defined in OIDC Spec** (both fields can be defined, see next note).
+- **If issuerEndpoint plain value is defined in CR - it will be used as precedence over issuerEndpointRef secret**.
+
 ##### IssuerEndpointRef  
 - Example of definition of IssuerEndpointRef in OIDCSpec 
 ```yaml


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/THREESCALE-10646
**Integration branch: [integration-mappingrules-10238](https://github.com/valerymo/3scale-operator/tree/integration-mappingrules-10238)**
**- PR created instead of original PR/branch https://github.com/3scale/3scale-operator/pull/903, that will be closed. Please see Review comments in PR 903**

- This task is related to Bug https://issues.redhat.com/browse/THREESCALE-10238 - The Operator reconciles a Product created with the ProductCR when mapping rules are duplicated.  

Additional tasks related to [THREESCALE-10238](https://issues.redhat.com//browse/THREESCALE-10238) were opened, to investigate and fix issues found during curent development:
- Method added via UI is not saved, dissapered after rerun 3scale (make run). So Rules added via UI and using method that created via UI - dissapering after operator stop/start  - https://issues.redhat.com/browse/THREESCALE-10647
- Check Sorting/order of Mapping rules that added via UI with different position (beginning (0),  end, middle). Check that mapping list in UI is stable --> https://issues.redhat.com/browse/THREESCALE-10648

## WHAT

Current PR is intended for Investigation and Initial  Fix of following problems:
- 3scale UI Product Integration page- Configuration History was updated in each reconciliation cycle, even if no changes in mapping rules. Maping rules Position changed in each reconciliation cycle (looks like this impacted on Configuration History)
- Mapping rule `metricMethod` parameter was appear incorrectly in 3scale UI Product MappingRule page for those rules that were defined in Product CR and had same Verb+httpMethod. See image below - difference beween in UI and CR.

![Screenshot from 2023-12-07 13-01-05](https://github.com/3scale/3scale-operator/assets/56625811/60e008b1-45e3-487d-bd1c-0c4c428a891b)

## Validation notes

- Get current branch, Install and run 3scale locally:

```
make install
oc new-project 3scale-test
make download
make run
``` 

- On another window:
Apply following files. The examples for backend and product - provided below. Other - please ask me if required.

```
oc apply -f s3-creds-secret.yaml
oc apply -f apimanagerCR.yaml
oc apply -f backend.yml
oc apply -f product2.yml
```
```
apiVersion: capabilities.3scale.net/v1beta1
kind: Backend
metadata:
  name: backend1
spec:
  name: "Operated Backend 1"
  systemName: "backend1"
  description: "Operated Backend 1 for reconciliation testing"
  privateBaseURL: "https://example.3scale.net"
```
**Test 1** is using this product yaml

```
apiVersion: capabilities.3scale.net/v1beta1
kind: Product
metadata:
  name: product2
spec:
  name: "OperatedProduct 2"
  systemName: "operatedproduct2"
  description: "Operated Product 2 for reconciliation testing"
  backendUsages:
    backend1:
      path: /
  mappingRules:
    - httpMethod: GET
      increment: 1
      metricMethodRef: hits
      pattern: /pets
    - httpMethod: GET
      increment: 1
      metricMethodRef: hits
      pattern: /cars
    - httpMethod: GET
      increment: 1
      metricMethodRef: method01
      pattern: /pets
  metrics:
    hits:
      description: Number of API hits
      friendlyName: Hits
      unit: hit
  methods:
    method01:
      friendlyName: Method01
```

- Check 3scale portal - Mapping rules expected to be like following:
![Screenshot from 2023-12-12 13-35-58](https://github.com/3scale/3scale-operator/assets/56625811/74875634-6d8c-4ff2-841d-6ff71b46ab84)
- Check Configuration page and promote to Stage and Production

- rerun 3scale (make run), and check:
  -  Mapping rules appearence didn't change
  - Check Configuration page - it should Not require updates.

**Test 2**
- Add rules via UI
- rerun 3scale (make run), and check:
  - Mapping rules appearence didn't change
  - Configuration page - it should Not require updates  
  - Mapping rules expected to be like in image (where first 3 rules - from CR, and other added via UI at the end)
![Screenshot from 2024-01-11 09-58-41](https://github.com/3scale/3scale-operator/assets/56625811/17f32a06-6b16-4abd-951b-205bd46e0cf1)

- Try add rules with different position 
This is example:
![Screenshot from 2024-01-11 10-16-46](https://github.com/3scale/3scale-operator/assets/56625811/8ba7c3f3-564c-4ec3-9260-e5a2f075fd22)


**Test3**
Test case when Identical Rules presebt in Product CR.
(no Rules added from UI)

 - Apply following CR yaml
```yaml
apiVersion: capabilities.3scale.net/v1beta1
kind: Product
metadata:
  name: product3
spec:
  name: "OperatedProduct 3"
  systemName: "operatedproduct3"
  description: "Operated Product 3 for reconciliation testing"
  backendUsages:
    backend1:
      path: /
  mappingRules:
    - httpMethod: PUT
      increment: 1
      metricMethodRef: hits
      pattern: /pets
    - httpMethod: GET
      increment: 1
      metricMethodRef: hits
      pattern: /pets      
    - httpMethod: GET
      increment: 1
      metricMethodRef: hits
      pattern: /cars
    - httpMethod: GET
      increment: 1
      metricMethodRef: method01
      pattern: /pets
    - httpMethod: GET
      increment: 1
      metricMethodRef: method01
      pattern: /pets
  metrics:
    hits:
      description: Number of API hits
      friendlyName: Hits
      unit: hit
  methods:
    method01:
      friendlyName: Method01
```

- Product CR created
```
$ oc describe product product3
Name:         product3
Namespace:    3scale-test
Labels:       <none>
Annotations:  <none>
API Version:  capabilities.3scale.net/v1beta1
Kind:         Product
Metadata:
  Creation Timestamp:  2024-01-14T16:51:45Z
....
Spec:
  Backend Usages:
    backend1:
      Path:     /
  Description:  Operated Product 3 for reconciliation testing
  Mapping Rules:
    Http Method:        PUT
    Increment:          1
    Metric Method Ref:  hits
    Pattern:            /pets
    Http Method:        GET
    Increment:          1
    Metric Method Ref:  hits
    Pattern:            /pets
    Http Method:        GET
    Increment:          1
    Metric Method Ref:  hits
    Pattern:            /cars
    Http Method:        GET
    Increment:          1
    Metric Method Ref:  method01
    Pattern:            /pets
    Http Method:        GET
    Increment:          1
    Metric Method Ref:  method01
    Pattern:            /pets
  Methods:
    method01:
      Friendly Name:  Method01
  Metrics:
    Hits:
      Description:    Number of API hits
      Friendly Name:  Hits
      Unit:           hit
  Name:               OperatedProduct 3
  Policies:
    Configuration:
    Configuration Ref:
    Enabled:    true
    Name:       apicast
    Version:    builtin
  System Name:  operatedproduct3
Status:
  Conditions:
    ....
    Status:                True
    Type:                  Synced
  Observed Generation:     2
  Product Id:              4
  Provider Account Host:   https://3scale-admin.apps.vmo01.m2br.s1.devshift.org
Events:                    <none>
```
- Product Page in UI - All rules are present in same order as  in CR

![Screenshot from 2024-01-14 18-56-09](https://github.com/3scale/3scale-operator/assets/56625811/0c0cf189-b3c4-40af-89aa-257d2f84fde8)

- Restart 3scale and check  following: 
     - Product CR and UI/3scale portal - remains no changes
     - No Integration configuration changes.
     - Please see image below - after operator restart.
     
![Screenshot from 2024-01-14 19-08-00](https://github.com/3scale/3scale-operator/assets/56625811/1f619072-4ad8-4e39-bc51-363b74c8d5aa)

     